### PR TITLE
Feature: make user able to delete all tasks from a specific column

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [x] User can reorder the columns by dragging and dropping them
 - [x] User can create tasks
 - [x] User can delete tasks
+- [x] User can delete all tasks of a column (shortcut to save user's time)
 - [x] User can create columns
 - [x] User can delete columns
 - [x] User can edit a column name

--- a/src/components/Board/Board.test.tsx
+++ b/src/components/Board/Board.test.tsx
@@ -207,4 +207,34 @@ describe('Component: Board', () => {
       columns: [BoardMock.columns[0]]
     });
   });
+
+  it('should delete all tasks from a column correctly', async () => {
+    const setBoardMock = jest.fn();
+
+    renderWithTheme(<Board board={BoardMock} setBoard={setBoardMock} />);
+
+    const firstColumn = within(screen.getAllByLabelText('Tasks column')[0]);
+
+    expect(firstColumn.getByRole('heading', { name: 'To do' })).toBeInTheDocument();
+    expect(firstColumn.getByLabelText('Tasks of the "To do" column').children).toHaveLength(2);
+
+    await userEvent.click(firstColumn.getByRole('button', { name: 'Open dropdown' }));
+    await userEvent.click(firstColumn.getByText('Delete all tasks'));
+
+    await screen.findByLabelText('Modal with title "Delete all tasks"');
+    await userEvent.click(screen.getByRole('button', { name: 'Yes, delete all tasks' }));
+
+    expect(setBoardMock).toHaveBeenCalledTimes(1);
+    expect(setBoardMock).toHaveBeenCalledWith({
+      ...BoardMock,
+      columns: [
+        {
+          id: 'todo-column-id',
+          title: 'To do',
+          tasks: []
+        },
+        BoardMock.columns[1]
+      ]
+    });
+  });
 });

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -12,7 +12,8 @@ import {
   useHandleDeleteTask,
   useHandleDeleteColumn,
   useHandleEditColumn,
-  useHandleAddColumn
+  useHandleAddColumn,
+  useHandleDeleteAllTasks
 } from './logic';
 
 type BoardProps = {
@@ -35,6 +36,11 @@ export default function Board({ board, setBoard }: BoardProps) {
     isDeleteColumnConfirmationModalOpen,
     openDeleteColumnConfirmationModal,
     closeDeleteColumnConfirmationModal
+  ] = useModalState();
+  const [
+    isDeleteAllTasksConfirmationModalOpen,
+    openDeleteAllTasksConfirmationModal,
+    closeDeleteAllTasksConfirmationModal
   ] = useModalState();
   const [isEditColumnModalOpen, openEditColumnModal, closeEditColumnModal] = useModalState();
 
@@ -89,6 +95,13 @@ export default function Board({ board, setBoard }: BoardProps) {
     closeAddColumnModal
   });
 
+  const handleDeleteAllTasks = useHandleDeleteAllTasks({
+    board,
+    currentColumn,
+    setBoard,
+    closeDeleteAllTasksConfirmationModal
+  });
+
   return (
     <S.Wrapper>
       <DragDropContext onDragEnd={onDragEnd}>
@@ -116,6 +129,10 @@ export default function Board({ board, setBoard }: BoardProps) {
                   handleDeleteColumn={() => {
                     setCurrentColumn(column);
                     openDeleteColumnConfirmationModal();
+                  }}
+                  handleDeleteAllTasks={() => {
+                    setCurrentColumn(column);
+                    openDeleteAllTasksConfirmationModal();
                   }}
                 />
               ))}
@@ -189,6 +206,21 @@ export default function Board({ board, setBoard }: BoardProps) {
         }}
         isOpen={isDeleteColumnConfirmationModalOpen}
         onClose={closeDeleteColumnConfirmationModal}
+      />
+
+      <ConfirmationModal
+        title='Delete all tasks'
+        content='Are you sure you want to delete all tasks from this column?'
+        cancelButtonProps={{
+          children: "No, I'm not sure"
+        }}
+        confirmButtonProps={{
+          color: 'danger',
+          children: 'Yes, delete all tasks',
+          onClick: handleDeleteAllTasks
+        }}
+        isOpen={isDeleteAllTasksConfirmationModalOpen}
+        onClose={closeDeleteAllTasksConfirmationModal}
       />
     </S.Wrapper>
   );

--- a/src/components/Board/logic/index.ts
+++ b/src/components/Board/logic/index.ts
@@ -3,3 +3,4 @@ export { default as useHandleDeleteTask } from './useHandleDeleteTask/useHandleD
 export { default as useHandleDeleteColumn } from './useHandleDeleteColumn/useHandleDeleteColumn';
 export { default as useHandleEditColumn } from './useHandleEditColumn/useHandleEditColumn';
 export { default as useHandleAddColumn } from './useHandleAddColumn/useHandleAddColumn';
+export { default as useHandleDeleteAllTasks } from './useHandleDeleteAllTasks/useHandleDeleteAllTasks';

--- a/src/components/Board/logic/useHandleDeleteAllTasks/useHandleDeleteAllTasks.test.ts
+++ b/src/components/Board/logic/useHandleDeleteAllTasks/useHandleDeleteAllTasks.test.ts
@@ -1,0 +1,72 @@
+import { Board } from 'types';
+import useHandleDeleteAllTasks from './useHandleDeleteAllTasks';
+
+const BOARD_MOCK: Board = {
+  id: 'fake-id',
+  slug: 'fake-slug',
+  title: 'fake-board',
+  columns: [
+    {
+      id: 'column-1',
+      title: 'Column 1',
+      tasks: [
+        {
+          id: 'fake-task-1',
+          content: 'Fake first task'
+        },
+        {
+          id: 'fake-task-2',
+          content: 'Fake second task'
+        },
+        {
+          id: 'fake-task-3',
+          content: 'Fake third task'
+        }
+      ]
+    },
+    {
+      id: 'column-2',
+      title: 'Column 2',
+      tasks: [
+        {
+          id: 'fake-task-4',
+          content: 'Fake fourth task'
+        }
+      ]
+    }
+  ]
+};
+
+describe('Component: Board > Logic hook: useHandleDeleteAllTasks', () => {
+  it('should call setBoard and closeModal correctly', () => {
+    // as this hook doesn't use any React logic, we don't need to use @testing-library/react-hooks
+    const closeDeleteAllTasksConfirmationModalMock = jest.fn();
+    const setBoardMock = jest.fn();
+
+    const handleDeleteColumn = useHandleDeleteAllTasks({
+      board: BOARD_MOCK,
+      currentColumn: BOARD_MOCK.columns[0],
+      closeDeleteAllTasksConfirmationModal: closeDeleteAllTasksConfirmationModalMock,
+      setBoard: setBoardMock
+    });
+
+    handleDeleteColumn();
+
+    expect(setBoardMock).toHaveBeenCalledTimes(1);
+    expect(setBoardMock).toHaveBeenCalledWith({
+      id: 'fake-id',
+      slug: 'fake-slug',
+      title: 'fake-board',
+      columns: [
+        {
+          id: 'column-1',
+          title: 'Column 1',
+          tasks: []
+        },
+        BOARD_MOCK.columns[1]
+      ]
+    });
+
+    expect(closeDeleteAllTasksConfirmationModalMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Board/logic/useHandleDeleteAllTasks/useHandleDeleteAllTasks.ts
+++ b/src/components/Board/logic/useHandleDeleteAllTasks/useHandleDeleteAllTasks.ts
@@ -1,0 +1,28 @@
+import { Board, Column } from 'types';
+type UseHandleDeleteColumnParams = {
+  board: Board;
+  currentColumn: Column | null;
+  setBoard: (board: Board) => void;
+  closeDeleteAllTasksConfirmationModal: () => void;
+};
+
+export default function useHandleDeleteColumn({
+  board,
+  currentColumn,
+  setBoard,
+  closeDeleteAllTasksConfirmationModal
+}: UseHandleDeleteColumnParams) {
+  return () => {
+    if (!currentColumn) return;
+
+    const newColumn: Column = { ...currentColumn, tasks: [] };
+    const columnIndex = board.columns.findIndex((column) => column.id === currentColumn.id);
+
+    const newBoard: Board = structuredClone(board);
+
+    newBoard.columns.splice(columnIndex, 1, newColumn);
+
+    setBoard(newBoard);
+    closeDeleteAllTasksConfirmationModal();
+  };
+}

--- a/src/components/TasksColumn/TasksColumn.stories.tsx
+++ b/src/components/TasksColumn/TasksColumn.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { DragDropContext } from 'react-beautiful-dnd';
 import TasksColumn from './TasksColumn';
 
 export default {
@@ -19,6 +20,10 @@ export default {
 
     handleDeleteColumn: {
       action: 'delete column requested'
+    },
+
+    handleDeleteAllTasks: {
+      action: 'delete all tasks from a specific column requested'
     },
 
     column: {
@@ -48,6 +53,8 @@ export default {
 
 export const Basic: ComponentStory<typeof TasksColumn> = (args) => (
   <div style={{ padding: 6, backgroundColor: '#eaeaea', width: 'min-content' }}>
-    <TasksColumn {...args} />
+    <DragDropContext onDragEnd={() => {}}>
+      <TasksColumn {...args} />
+    </DragDropContext>
   </div>
 );

--- a/src/components/TasksColumn/TasksColumn.test.tsx
+++ b/src/components/TasksColumn/TasksColumn.test.tsx
@@ -9,6 +9,7 @@ const renderComponent = () => {
   const handleDeleteColumnMock = jest.fn();
   const handleDeleteTaskMock = jest.fn();
   const handleEditColumnMock = jest.fn();
+  const handleDeleteAllTasksMock = jest.fn();
 
   renderWithTheme(
     <DragDropContext onDragEnd={() => {}}>
@@ -33,6 +34,7 @@ const renderComponent = () => {
         handleDeleteColumn={handleDeleteColumnMock}
         handleDeleteTask={handleDeleteTaskMock}
         handleEditColumn={handleEditColumnMock}
+        handleDeleteAllTasks={handleDeleteAllTasksMock}
       />
     </DragDropContext>
   );
@@ -41,7 +43,8 @@ const renderComponent = () => {
     handleAddTaskMock,
     handleDeleteColumnMock,
     handleDeleteTaskMock,
-    handleEditColumnMock
+    handleEditColumnMock,
+    handleDeleteAllTasksMock
   };
 };
 
@@ -84,5 +87,15 @@ describe('Component: TasksColumn', () => {
     await userEvent.click(screen.getByText('Edit column'));
 
     expect(handleEditColumnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call handleDeleteAllTasks when user clicks on "Delete all tasks" dropdown option', async () => {
+    const { handleDeleteAllTasksMock } = renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open dropdown' }));
+
+    await userEvent.click(screen.getByText('Delete all tasks'));
+
+    expect(handleDeleteAllTasksMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/TasksColumn/TasksColumn.tsx
+++ b/src/components/TasksColumn/TasksColumn.tsx
@@ -4,6 +4,7 @@ import DropdownMenu from 'components/DropdownMenu/DropdownMenu';
 import { Column } from 'types';
 import { Pencil as PencilIcon, Trash as TrashIcon } from '@styled-icons/evil';
 import { Plus as PlusIcon } from '@styled-icons/feather';
+import { Broom as ClearAllIcon } from '@styled-icons/fluentui-system-filled';
 import { TaskCard } from 'components';
 import { DraggableProvided, Droppable } from 'react-beautiful-dnd';
 
@@ -13,6 +14,7 @@ export type TasksColumnProps = {
   handleDeleteTask: (taskIndex: number) => void;
   handleEditColumn: () => void;
   handleDeleteColumn: () => void;
+  handleDeleteAllTasks: () => void;
   provided?: DraggableProvided;
 };
 
@@ -25,6 +27,7 @@ export default function TasksColumn({
   handleDeleteTask,
   handleEditColumn,
   handleDeleteColumn,
+  handleDeleteAllTasks,
   provided
 }: TasksColumnProps) {
   return (
@@ -53,6 +56,11 @@ export default function TasksColumn({
               icon: <TrashIcon />,
               text: 'Delete column',
               onClick: handleDeleteColumn
+            },
+            {
+              icon: <ClearAllIcon />,
+              text: 'Delete all tasks',
+              onClick: handleDeleteAllTasks
             }
           ]}
           ariaLabel='Column related actions'


### PR DESCRIPTION
This PR implements a feature to make the user able to delete all tasks from a specific column, I have implemented it in order to solve a necessity of my own, in the day-to-day use of the app there were many times where I wish I could be able to delete all tasks from a specific column, and as I think this is a useful feature, I implemented it!